### PR TITLE
Use single context object for nodes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.mmm.his.cer.utility</groupId>
   <artifactId>farser</artifactId>
-  <version>3.4.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <properties>
     <java_version>1.8</java_version>

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
@@ -2,6 +2,7 @@ package com.mmm.his.cer.utility.farser.ast;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -11,28 +12,27 @@ import java.util.Set;
  *
  * @author Mike Funaro
  */
-public class DrgSyntaxTree<T> {
+public class DrgSyntaxTree<C> {
 
-  private BooleanExpression<T> ast;
+  private BooleanExpression<C> ast;
 
-  public DrgSyntaxTree(BooleanExpression<T> ast) {
+  public DrgSyntaxTree(BooleanExpression<C> ast) {
     this.ast = ast;
   }
 
-  public void setAst(BooleanExpression<T> ast) {
+  public void setAst(BooleanExpression<C> ast) {
     this.ast = ast;
   }
 
   /**
    * Evaluate an expression that was previously built by the parser.
    *
-   * @param operands the list of operand objects that we want to match against.
+   * @param context the context object that will be used in the evaluation.
    * @return {@link ExpressionResult}
-   *     ExpressionResult object which will have a the data about the outcome of the evaluation.
+   *     ExpressionResult object which will have the data about the outcome of the evaluation.
    */
-  public ExpressionResult<T> evaluateExpression(List<T> operands) {
-    Set<T> matches = new LinkedHashSet<>();
-    boolean evaluate = this.ast.evaluate(operands, matches);
-    return new ExpressionResult<>(evaluate, matches);
+  public ExpressionResult<C> evaluateExpression(C context) {
+    boolean evaluate = this.ast.evaluate(context);
+    return new ExpressionResult<>(evaluate, context);
   }
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
@@ -3,10 +3,6 @@ package com.mmm.his.cer.utility.farser.ast;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 /**
  * Class that wraps a {@link BooleanExpression} and provides methods to evaluate it.
  *

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
@@ -1,21 +1,19 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This class represents a logical AND
  * operation.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class And<T> extends NonTerminal<T> {
+public class And<C> extends NonTerminal<C> {
 
   @Override
-  public boolean evaluate(List<T> operands, Set<T> accumulator) {
-    return left.evaluate(operands, accumulator) && right.evaluate(operands, accumulator);
+  public boolean evaluate(C context) {
+    return left.evaluate(context) && right.evaluate(context);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
@@ -2,17 +2,15 @@ package com.mmm.his.cer.utility.farser.ast.node.operator;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This type of node will only have a left
  * child and no right child. It's evaluation should negate the result of the left child.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Not<T> extends NonTerminal<T> {
+public class Not<C> extends NonTerminal<C> {
 
   /**
    * For a not node, we should only set one child. This method sets the left child only. And should
@@ -20,19 +18,19 @@ public class Not<T> extends NonTerminal<T> {
    *
    * @param child the child for this node.
    */
-  public void setChild(BooleanExpression<T> child) {
+  public void setChild(BooleanExpression<C> child) {
     setLeft(child);
   }
 
   @Override
-  public void setRight(BooleanExpression<T> right) {
+  public void setRight(BooleanExpression<C> right) {
     // Not nodes will only have one child and that is the left child. Throw error.
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean evaluate(List<T> operands, Set<T> accumulator) {
-    boolean evaluation = left.evaluate(operands, accumulator);
+  public boolean evaluate(C context) {
+    boolean evaluation = left.evaluate(context);
     return !evaluation;
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
@@ -13,13 +13,7 @@ public class Or<C> extends NonTerminal<C> {
 
   @Override
   public boolean evaluate(C context) {
-    boolean leftTrue = left.evaluate(context);
-
-    if (leftTrue) {
-      return true;
-    }
-
-    return right.evaluate(context);
+    return left.evaluate(context) || right.evaluate(context);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
@@ -1,27 +1,25 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This class represents a logical OR
  * operation.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Or<T> extends NonTerminal<T> {
+public class Or<C> extends NonTerminal<C> {
 
   @Override
-  public boolean evaluate(List<T> operands, Set<T> accumulator) {
-    boolean leftTrue = left.evaluate(operands, accumulator);
+  public boolean evaluate(C context) {
+    boolean leftTrue = left.evaluate(context);
 
     if (leftTrue) {
       return true;
     }
 
-    return right.evaluate(operands, accumulator);
+    return right.evaluate(context);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
@@ -1,7 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node.terminal;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-
 import java.util.Collection;
 
 /**

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
@@ -1,31 +1,27 @@
 package com.mmm.his.cer.utility.farser.ast.node.terminal;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import java.util.List;
-import java.util.Set;
+
+import java.util.Collection;
 
 /**
- * A terminal node that represents an an evaluation that centers around the list#contains. This node
+ * A terminal node that represents an evaluation that centers around the list#contains. This node
  * will check the incoming values to see if the field value is contained with in it.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class ContainsNode<T> implements BooleanExpression<T> {
+public class ContainsNode<C extends Collection<A>, A> implements BooleanExpression<C> {
 
-  private final T value;
+  private final A value;
 
-  public ContainsNode(T value) {
+  public ContainsNode(A value) {
     this.value = value;
   }
 
   @Override
-  public boolean evaluate(List<T> values, Set<T> accumulator) {
-    boolean contains = values.contains(this.value);
-    if (contains) {
-      accumulator.add(value);
-    }
-    return contains;
+  public boolean evaluate(C context) {
+    return context.contains(this.value);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -1,22 +1,19 @@
 package com.mmm.his.cer.utility.farser.ast.node.type;
 
-import java.util.List;
-import java.util.Set;
-
 /**
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The type of context to be used for the terminal node execution.
  * @author Mike Funaro
  */
-public interface BooleanExpression<T> {
+public interface BooleanExpression<C> {
 
   /**
    * Evaluate an expression returning true or false based on tests against the operands sent in.
    *
-   * @param operands the list of operands to buildExpressionTree the boolean test around
+   * @param context     The context that will be used in the evaluation of the node.
    * @return true or false.
    */
-  boolean evaluate(List<T> operands, Set<T> accumulator);
+  boolean evaluate(C context);
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -30,7 +30,7 @@ public class DescentParser<T> {
   /**
    * Ctor.
    *
-   * @param tokenIterator   list of tokens to parse into the AbstrA syntax tree.
+   * @param tokenIterator   list of tokens to parse into the Abstract syntax tree.
    * @param defaultSupplier the object that will take the current token and return an object
    *                        of the generic T defined for this class.
    */

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -30,7 +30,7 @@ public class DescentParser<T> {
   /**
    * Ctor.
    *
-   * @param tokenIterator   list of tokens to parse into the Abstract syntax tree.
+   * @param tokenIterator   list of tokens to parse into the AbstrA syntax tree.
    * @param defaultSupplier the object that will take the current token and return an object
    *                        of the generic T defined for this class.
    */

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/ExpressionResult.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/ExpressionResult.java
@@ -1,17 +1,15 @@
 package com.mmm.his.cer.utility.farser.ast.parser;
 
-import java.util.Set;
-
 /**
  * Class that contains all information about a expression match from {@link DescentParser}.
  *
- * @param <T> the type of object that will be contains in the matches set.
+ * @param <C> the type of context
  * @author Mike Funaro
  */
-public class ExpressionResult<T> {
+public class ExpressionResult<C> {
 
   private final boolean matched;
-  private final Set<T> matches;
+  private final C context;
 
   /**
    * Ctor.
@@ -19,18 +17,18 @@ public class ExpressionResult<T> {
    * @param matched boolean true if the expression evaluated to true, false otherwise. When there is
    *                true in the matched field the contents of the matches field will have the
    *                terminal objects that were matched.
-   * @param matches set of terminal objects that were matched during the expression evaluation.
+   * @param context the context used in evaluation.
    */
-  public ExpressionResult(boolean matched, Set<T> matches) {
+  public ExpressionResult(boolean matched, C context) {
     this.matched = matched;
-    this.matches = matches;
+    this.context = context;
   }
 
   public boolean isMatched() {
     return matched;
   }
 
-  public Set<T> getMatches() {
-    return matches;
+  public C getContext() {
+    return context;
   }
 }


### PR DESCRIPTION
Update `BooleanExpression` so that the generics are not bound to a List and Set. Instead us a single generic type that is the parameter to the execute method. This way, the user can fully define how they want to leverage nodes and since the majority of the nodes are user supplied, this gives full control over how the node logic is setup and how to get data into the nodes. 

Various classes updated to handle the new `BooleanExpression` generic types. 

Update unit tests.