### PR TITLE
Formula evaluation order testing and documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,8 +77,39 @@ prefix (e.g. "PFX:val" is split into prefix "PFX" and value "val").
 
 The Descent Parser can take a `ListIterator` of type `DrgFormulaToken`s and build an Abstract 
 Syntax Tree, which can then be used to "evaluate" the expression against a list of operands. The 
-AST contains the boolean logic of the formula and can evaluate a given list of operands to see 
-if the operands would evaluate to true or false. 
+AST contains the **boolean** logic of the formula and can evaluate a given list of operands to see 
+if the operands would evaluate to true or false.
+
+The purpose of the parser is not only to evaluate a formula (for which other approaches like 
+[Apache Commons JEXL](https://commons.apache.org/proper/commons-jexl/reference/examples.html#Evaluating_Expressions) 
+could be used), but also to interact with the evaluation during its processing operation. The 
+"terminal nodes" (the ones where an evaluation has to happen) can be provided at AST construction 
+time and can implement any necessary evaluation and/or inspection logic.
+
+
+**Parser operator precedence:**
+
+The operators in the following table are listed according to precedence order. The closer to the 
+top of the table an operator appears, the higher its precedence.
+
+| Operator           | DrgFormulaToken |
+| ------------------ | --------------- |
+| unary NOT          |  ~              |
+| logical/binary AND |  &              |
+| logical/binary OR  |  \|             |
+
+
+**Evaluation order:** Formula evaluation happens from left to right. Only relevant portions of the 
+formula will get evaluated (until a `true` result is achieved). See also: 
+[Short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation).
+
+Examples: 
+
+ * `A & B | C` = `(A & B) | C` -> with `A=true`, `B=true`, `C=true`, it evaluates "A & B" only
+ * `C | A & B` = `C | (A & B)` -> with `A=true`, `B=true`, `C=true`, it evaluates "C" only
+
+
+
 
 #### Descent Parser Generic Type
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
@@ -6,17 +6,18 @@ import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 /**
  * Class that wraps a {@link BooleanExpression} and provides methods to evaluate it.
  *
+ * @param <T> the type of context
  * @author Mike Funaro
  */
-public class DrgSyntaxTree<C> {
+public class DrgSyntaxTree<T> {
 
-  private BooleanExpression<C> ast;
+  private BooleanExpression<T> ast;
 
-  public DrgSyntaxTree(BooleanExpression<C> ast) {
+  public DrgSyntaxTree(BooleanExpression<T> ast) {
     this.ast = ast;
   }
 
-  public void setAst(BooleanExpression<C> ast) {
+  public void setAst(BooleanExpression<T> ast) {
     this.ast = ast;
   }
 
@@ -24,10 +25,10 @@ public class DrgSyntaxTree<C> {
    * Evaluate an expression that was previously built by the parser.
    *
    * @param context the context object that will be used in the evaluation.
-   * @return {@link ExpressionResult}
-   *     ExpressionResult object which will have the data about the outcome of the evaluation.
+   * @return {@link ExpressionResult} ExpressionResult object which will have the data about the
+   *         outcome of the evaluation.
    */
-  public ExpressionResult<C> evaluateExpression(C context) {
+  public ExpressionResult<T> evaluateExpression(T context) {
     boolean evaluate = this.ast.evaluate(context);
     return new ExpressionResult<>(evaluate, context);
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
@@ -6,13 +6,13 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * Implementation of a non-terminal node for use in the AST. This class represents a logical AND
  * operation.
  *
- * @param <C> The context type used in the terminal nodes.
+ * @param <T> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class And<C> extends NonTerminal<C> {
+public class And<T> extends NonTerminal<T> {
 
   @Override
-  public boolean evaluate(C context) {
+  public boolean evaluate(T context) {
     return left.evaluate(context) && right.evaluate(context);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
@@ -7,10 +7,10 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * Implementation of a non-terminal node for use in the AST. This type of node will only have a left
  * child and no right child. It's evaluation should negate the result of the left child.
  *
- * @param <C> The context type used in the terminal nodes.
+ * @param <T> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Not<C> extends NonTerminal<C> {
+public class Not<T> extends NonTerminal<T> {
 
   /**
    * For a not node, we should only set one child. This method sets the left child only. And should
@@ -18,18 +18,18 @@ public class Not<C> extends NonTerminal<C> {
    *
    * @param child the child for this node.
    */
-  public void setChild(BooleanExpression<C> child) {
+  public void setChild(BooleanExpression<T> child) {
     setLeft(child);
   }
 
   @Override
-  public void setRight(BooleanExpression<C> right) {
+  public void setRight(BooleanExpression<T> right) {
     // Not nodes will only have one child and that is the left child. Throw error.
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean evaluate(C context) {
+  public boolean evaluate(T context) {
     boolean evaluation = left.evaluate(context);
     return !evaluation;
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
@@ -6,13 +6,13 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * Implementation of a non-terminal node for use in the AST. This class represents a logical OR
  * operation.
  *
- * @param <C> The context type used in the terminal nodes.
+ * @param <T> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Or<C> extends NonTerminal<C> {
+public class Or<T> extends NonTerminal<T> {
 
   @Override
-  public boolean evaluate(C context) {
+  public boolean evaluate(T context) {
     return left.evaluate(context) || right.evaluate(context);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -4,16 +4,16 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.
  *
- * @param <C> The type of context to be used for the terminal node execution.
+ * @param <T> The type of context to be used for the terminal node execution.
  * @author Mike Funaro
  */
-public interface BooleanExpression<C> {
+public interface BooleanExpression<T> {
 
   /**
    * Evaluate an expression returning true or false based on tests against the operands sent in.
    *
-   * @param context     The context that will be used in the evaluation of the node.
+   * @param context The context that will be used in the evaluation of the node.
    * @return true or false.
    */
-  boolean evaluate(C context);
+  boolean evaluate(T context);
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NodeSupplier.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NodeSupplier.java
@@ -6,12 +6,12 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  *
  * @param <T> the token type that will be used to create the node, based on the list of lexed tokens
  *            that are used to create the AST
- * @param <C> the parametric type on {@link BooleanExpression} - the context data passed in when the
+ * @param <R> the parametric type on {@link BooleanExpression} - the context data passed in when the
  *            AST is evaluated
  *
  * @author Mike Funaro
  */
-public interface NodeSupplier<T, C> {
+public interface NodeSupplier<T, R> {
 
   /**
    * Create a terminal node. This is type defined on the class. The input will be a token of a
@@ -21,5 +21,5 @@ public interface NodeSupplier<T, C> {
    * @param token The formula token/operand for which to create the node for
    * @return BooleanExpression that was instantiated in this method.
    */
-  BooleanExpression<C> createNode(T token);
+  BooleanExpression<R> createNode(T token);
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NodeSupplier.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NodeSupplier.java
@@ -4,18 +4,22 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  * Interface for calling applications to implement so that they can provide custom terminal nodes
  * for special logic to be evaluated within the AST.
  *
- * @param <T> the token type that will be used to create the node
- * @param <R> the parametric type on {@link BooleanExpression}
+ * @param <T> the token type that will be used to create the node, based on the list of lexed tokens
+ *            that are used to create the AST
+ * @param <C> the parametric type on {@link BooleanExpression} - the context data passed in when the
+ *            AST is evaluated
+ *
  * @author Mike Funaro
  */
-public interface NodeSupplier<T, R> {
+public interface NodeSupplier<T, C> {
 
   /**
    * Create a terminal node. This is type defined on the class. The input will be a token of a
    * particular type which is used in the body of the method to create an instance of
    * {@link BooleanExpression} that is type defined again using the types on the class.
    *
+   * @param token The formula token/operand for which to create the node for
    * @return BooleanExpression that was instantiated in this method.
    */
-  BooleanExpression<R> createNode(T token);
+  BooleanExpression<C> createNode(T token);
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -1,22 +1,22 @@
 package com.mmm.his.cer.utility.farser.ast.node.type;
 
 /**
- * This class represents a non-terminal node in the AST. These types of nodes will have a left and
- * a right child.
+ * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
+ * right child.
  *
- * @param <T> The type used in the terminal nodes.
+ * @param <C> The type used in the terminal nodes.
  * @author Mike Funaro
  */
-public abstract class NonTerminal<T> implements BooleanExpression<T> {
+public abstract class NonTerminal<C> implements BooleanExpression<C> {
 
-  protected BooleanExpression<T> left;
-  protected BooleanExpression<T> right;
+  protected BooleanExpression<C> left;
+  protected BooleanExpression<C> right;
 
-  public void setLeft(BooleanExpression<T> left) {
+  public void setLeft(BooleanExpression<C> left) {
     this.left = left;
   }
 
-  public void setRight(BooleanExpression<T> right) {
+  public void setRight(BooleanExpression<C> right) {
     this.right = right;
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -4,19 +4,19 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
  * right child.
  *
- * @param <C> The type used in the terminal nodes.
+ * @param <T> The type used in the terminal nodes.
  * @author Mike Funaro
  */
-public abstract class NonTerminal<C> implements BooleanExpression<C> {
+public abstract class NonTerminal<T> implements BooleanExpression<T> {
 
-  protected BooleanExpression<C> left;
-  protected BooleanExpression<C> right;
+  protected BooleanExpression<T> left;
+  protected BooleanExpression<T> right;
 
-  public void setLeft(BooleanExpression<C> left) {
+  public void setLeft(BooleanExpression<T> left) {
     this.left = left;
   }
 
-  public void setRight(BooleanExpression<C> right) {
+  public void setRight(BooleanExpression<T> right) {
     this.right = right;
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -10,6 +10,7 @@ import com.mmm.his.cer.utility.farser.lexer.FarserException;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgFormulaToken;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Map;
 
@@ -25,7 +26,7 @@ public class DescentParser<T> {
 
   private BooleanExpression<T> root;
   private DrgLexerToken currentToken;
-  private ListIterator<DrgLexerToken> tokenIterator;
+  private Iterator<DrgLexerToken> tokenIterator;
   private final NodeSupplier<DrgLexerToken, T> defaultSupplier;
   private final Map<String, NodeSupplier<DrgLexerToken, T>> suppliers;
 
@@ -39,7 +40,7 @@ public class DescentParser<T> {
    * @param suppliers       A map with node suppliers specific to certain tokens (token value as map
    *                        key)
    */
-  public DescentParser(ListIterator<DrgLexerToken> tokenIterator,
+  public DescentParser(Iterator<DrgLexerToken> tokenIterator,
       NodeSupplier<DrgLexerToken, T> defaultSupplier,
       Map<String, NodeSupplier<DrgLexerToken, T>> suppliers) {
     this.tokenIterator = tokenIterator;

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -19,15 +19,15 @@ import java.util.Map;
  *
  * @author Mike Funaro
  *
- * @param <C> The type of the context used when evaluating the AST
+ * @param <T> The type of the context used when evaluating the AST
  */
-public class DescentParser<C> {
+public class DescentParser<T> {
 
-  private BooleanExpression<C> root;
+  private BooleanExpression<T> root;
   private DrgLexerToken currentToken;
   private ListIterator<DrgLexerToken> tokenIterator;
-  private final NodeSupplier<DrgLexerToken, C> defaultSupplier;
-  private final Map<String, NodeSupplier<DrgLexerToken, C>> suppliers;
+  private final NodeSupplier<DrgLexerToken, T> defaultSupplier;
+  private final Map<String, NodeSupplier<DrgLexerToken, T>> suppliers;
 
   /**
    * Ctor.
@@ -40,8 +40,8 @@ public class DescentParser<C> {
    *                        key)
    */
   public DescentParser(ListIterator<DrgLexerToken> tokenIterator,
-      NodeSupplier<DrgLexerToken, C> defaultSupplier,
-      Map<String, NodeSupplier<DrgLexerToken, C>> suppliers) {
+      NodeSupplier<DrgLexerToken, T> defaultSupplier,
+      Map<String, NodeSupplier<DrgLexerToken, T>> suppliers) {
     this.tokenIterator = tokenIterator;
     this.currentToken = tokenIterator.next();
     if (defaultSupplier == null) {
@@ -71,7 +71,7 @@ public class DescentParser<C> {
   /**
    * Build the abstract syntax tree.
    */
-  public DrgSyntaxTree<C> buildExpressionTree() {
+  public DrgSyntaxTree<T> buildExpressionTree() {
     expression();
     return this.getAst();
   }
@@ -83,7 +83,7 @@ public class DescentParser<C> {
     term();
     while (currentToken.getType() == DrgFormulaToken.OR) {
       this.eat(DrgFormulaToken.OR);
-      Or<C> or = new Or<>();
+      Or<T> or = new Or<>();
       or.setLeft(root);
       term();
       or.setRight(root);
@@ -98,7 +98,7 @@ public class DescentParser<C> {
     factor();
     while (currentToken.getType() == DrgFormulaToken.AND) {
       this.eat(DrgFormulaToken.AND);
-      And<C> and = new And<>();
+      And<T> and = new And<>();
       and.setLeft(root);
       factor();
       and.setRight(root);
@@ -112,7 +112,7 @@ public class DescentParser<C> {
   private void factor() {
     if (currentToken.getType() == DrgFormulaToken.ATOM) {
 
-      NodeSupplier<DrgLexerToken, C> nodeSupplier = suppliers.getOrDefault(
+      NodeSupplier<DrgLexerToken, T> nodeSupplier = suppliers.getOrDefault(
           currentToken.value, defaultSupplier);
       root = nodeSupplier.createNode(currentToken);
       this.eat(DrgFormulaToken.ATOM);
@@ -122,7 +122,7 @@ public class DescentParser<C> {
       this.eat(DrgFormulaToken.RPAREN);
     } else if (currentToken.getType() == DrgFormulaToken.NOT) {
       this.eat(DrgFormulaToken.NOT);
-      Not<C> not = new Not<>();
+      Not<T> not = new Not<>();
       factor();
       not.setChild(root);
       root = not;
@@ -147,7 +147,7 @@ public class DescentParser<C> {
    *
    * @return new DrgSyntaxTree
    */
-  private DrgSyntaxTree<C> getAst() {
+  private DrgSyntaxTree<T> getAst() {
     return new DrgSyntaxTree<>(this.root);
   }
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/ExpressionResult.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/ExpressionResult.java
@@ -3,13 +3,13 @@ package com.mmm.his.cer.utility.farser.ast.parser;
 /**
  * Class that contains all information about a expression match from {@link DescentParser}.
  *
- * @param <C> the type of context
+ * @param <T> the type of context
  * @author Mike Funaro
  */
-public class ExpressionResult<C> {
+public class ExpressionResult<T> {
 
   private final boolean matched;
-  private final C context;
+  private final T context;
 
   /**
    * Ctor.
@@ -19,7 +19,7 @@ public class ExpressionResult<C> {
    *                terminal objects that were matched.
    * @param context the context used in evaluation.
    */
-  public ExpressionResult(boolean matched, C context) {
+  public ExpressionResult(boolean matched, T context) {
     this.matched = matched;
     this.context = context;
   }
@@ -28,7 +28,7 @@ public class ExpressionResult<C> {
     return matched;
   }
 
-  public C getContext() {
+  public T getContext() {
     return context;
   }
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/LexerToken.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/LexerToken.java
@@ -1,5 +1,7 @@
 package com.mmm.his.cer.utility.farser.lexer;
 
+import java.util.Optional;
+
 /**
  * Token class which represents the pieces of a lexed string.
  *
@@ -15,6 +17,17 @@ public interface LexerToken<T extends TokenType<?>> {
    * @return The token
    */
   T getType();
+
+  /**
+   * Returns the {@link CommonTokenType} for this token.
+   *
+   * @return The common token type
+   */
+  default Optional<CommonTokenType> getCommonType() {
+    T type = getType();
+    // Delegation for simpler access
+    return type == null ? Optional.empty() : type.getCommonTokenType();
+  }
 
   /**
    * The value of the token.<br />

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/domain/DomainCodeLexerToken.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/domain/DomainCodeLexerToken.java
@@ -3,6 +3,7 @@ package com.mmm.his.cer.utility.farser.lexer.domain;
 
 import com.mmm.his.cer.utility.farser.lexer.LexerToken;
 import com.mmm.his.cer.utility.farser.lexer.TokenType;
+import java.util.Objects;
 
 /**
  * Token class that can be used to represent the pieces of a lexed string.
@@ -43,6 +44,23 @@ public class DomainCodeLexerToken implements LexerToken<DomainCodeToken> {
   @Override
   public String getValue() {
     return value;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof DomainCodeLexerToken)) {
+      return false;
+    }
+    DomainCodeLexerToken other = (DomainCodeLexerToken) obj;
+    return type == other.type && Objects.equals(value, other.value);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/drg/DrgLexerToken.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/drg/DrgLexerToken.java
@@ -3,6 +3,7 @@ package com.mmm.his.cer.utility.farser.lexer.drg;
 
 import com.mmm.his.cer.utility.farser.lexer.LexerToken;
 import com.mmm.his.cer.utility.farser.lexer.TokenType;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -74,6 +75,24 @@ public class DrgLexerToken implements LexerToken<DrgFormulaToken> {
     return Optional.ofNullable(prefix);
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(prefix, type, value);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof DrgLexerToken)) {
+      return false;
+    }
+    DrgLexerToken other = (DrgLexerToken) obj;
+    return Objects.equals(prefix, other.prefix)
+        && type == other.type
+        && Objects.equals(value, other.value);
+  }
 
   @Override
   public String toString() {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
@@ -353,8 +353,7 @@ public class AstTest {
 
     // This third formula will pass the evaluation with the mask. Since it is all on the same level
     // it will be evaluated from left to right. A & B will be grouped as the LEFT side of the OR
-    // operator and C will be the RIGHT side. NOTE operators do not have precedence, hence left to
-    // right evaluation when there is no parentheses.
+    // operator and C will be the RIGHT side.
     List<DrgLexerToken> lexerTokens3 = DrgFormulaLexer.lex("A & B | C");
     DescentParser<MaskedContext<String>> parser3 = new DescentParser<>(lexerTokens3.listIterator(),
         new StringOperandSupplier(), suppliers);

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
@@ -60,7 +60,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A|B) & (D|E)");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     ExpressionResult<MaskedContext<String>> evaluation = ast.evaluateExpression(
@@ -74,7 +74,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ((B & C) & (D | E | (F & G)))");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Arrays.asList("B", "C", "F", "G");
@@ -92,7 +92,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ((B & C) & (D | E | (F & G)))");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     ExpressionResult<MaskedContext<String>> evaluation = ast.evaluateExpression(
@@ -105,7 +105,7 @@ public class AstTest {
   public void testLeftSideComplexLeftSideEval() {
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("((B & C) & (D | E | (F & G))) | A");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Arrays.asList("G", "F", "C", "B");
@@ -123,7 +123,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("((B & C) & (D | E | (F & G))) | A");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Collections.singletonList("A");
@@ -141,7 +141,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A | B| C| (D & (G & (F|H)))))");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Arrays.asList("D", "G", "H");
@@ -159,7 +159,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A | B| C| (D & (G & (F|H)))))");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     ExpressionResult<MaskedContext<String>> evaluation = ast.evaluateExpression(
@@ -173,7 +173,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ~B");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Collections.singletonList("A");
@@ -191,7 +191,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ~B");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Collections.singletonList("B");
@@ -206,7 +206,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ~B");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Collections.singletonList("G");
@@ -256,7 +256,7 @@ public class AstTest {
   public void testEvalOfAnotherAst() {
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | ~B");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
 
@@ -286,7 +286,7 @@ public class AstTest {
   public void testSingleListEval() {
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Collections.singletonList("A");
     ExpressionResult<MaskedContext<String>> evaluation = ast.evaluateExpression(
@@ -302,7 +302,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A|B) & (C|D)");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Arrays.asList("A", "C", "B");
@@ -330,7 +330,7 @@ public class AstTest {
     // This first formula will fail evaluation with the mask.
     List<DrgLexerToken> lexerTokens1 = DrgFormulaLexer.lex("A & (B|C)");
     DescentParser<MaskedContext<String>> parser1 = new DescentParser<>(lexerTokens1.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast1 = parser1.buildExpressionTree();
 
@@ -342,7 +342,7 @@ public class AstTest {
     // This second formula will pass the evaluation with the mask.
     List<DrgLexerToken> lexerTokens2 = DrgFormulaLexer.lex("(A & B) | C");
     DescentParser<MaskedContext<String>> parser2 = new DescentParser<>(lexerTokens2.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast2 = parser2.buildExpressionTree();
 
@@ -356,7 +356,7 @@ public class AstTest {
     // operator and C will be the RIGHT side.
     List<DrgLexerToken> lexerTokens3 = DrgFormulaLexer.lex("A & B | C");
     DescentParser<MaskedContext<String>> parser3 = new DescentParser<>(lexerTokens3.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast3 = parser3.buildExpressionTree();
 
@@ -379,7 +379,7 @@ public class AstTest {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & ~(B & C)");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new StringOperandSupplier(), suppliers);
+        new StringOperandSupplier(), Collections.emptyMap());
 
     DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
     List<String> mask = Arrays.asList("A", "C");

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
@@ -9,10 +9,6 @@ import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Mike Funaro
@@ -29,8 +28,8 @@ import java.util.Set;
 public class AstTest {
 
   final Map<String, NodeSupplier<DrgLexerToken, MaskedContext<String>>> suppliers = new HashMap<>();
-  final Map<String, NodeSupplier<DrgLexerToken, MaskedContext<CustomTestOperand>>> customOperandSuppliers
-      = new HashMap<>();
+  final Map<String, NodeSupplier<DrgLexerToken, MaskedContext<CustomTestOperand>>> customOperandSuppliers =
+      new HashMap<>();
 
   @Before
   public void setUp() {
@@ -53,7 +52,7 @@ public class AstTest {
 
     assertThat(evaluation.isMatched(), is(true));
     assertThat(context.getMatches().toArray(),
-        Matchers.arrayContaining(new Object[]{"luck", "E"}));
+        Matchers.arrayContaining(new Object[] {"luck", "E"}));
   }
 
   @Test
@@ -116,7 +115,7 @@ public class AstTest {
 
     assertThat(evaluation.isMatched(), is(true));
     assertThat(context.getMatches().toArray(),
-        Matchers.arrayContaining(new Object[]{"B", "C", "F", "G"}));
+        Matchers.arrayContaining(new Object[] {"B", "C", "F", "G"}));
   }
 
   @Test
@@ -313,14 +312,14 @@ public class AstTest {
     assertThat(evaluation.isMatched(), is(true));
     assertThat(context.getMatches().size(), is(2));
     assertThat(context.getMatches().toArray(),
-        Matchers.arrayContaining(new Object[]{"A", "C"}));
+        Matchers.arrayContaining(new Object[] {"A", "C"}));
   }
 
 
   /**
-   * Test proper handling of parentheses. Use the same formula but move the parentheses
-   * so that it is effectively a different formula. Testing using the same mask, one formula
-   * should pass, the other will fail.
+   * Test proper handling of parentheses. Use the same formula but move the parentheses so that it
+   * is effectively a different formula. Testing using the same mask, one formula should pass, the
+   * other will fail.
    */
   @Test
   public void testNestingEval() {
@@ -373,8 +372,8 @@ public class AstTest {
    * needs to be evaluated and a true outcome for the result to then be negated. E.G. if the formula
    * is ~(B & C) the mask would need to include B and C. The B & C part evaluates to true and then
    * the true result is negated, so false would come out of the NOT node. If only one of the B and C
-   * is present, the AND node evaluates to false, which in turn causes a true to come out of the
-   * NOT node, meaning that one or both of the B and C are not present.
+   * is present, the AND node evaluates to false, which in turn causes a true to come out of the NOT
+   * node, meaning that one or both of the B and C are not present.
    */
   @Test
   public void testNegationParentheses() {
@@ -414,7 +413,8 @@ public class AstTest {
         return false;
       }
       CustomTestOperand that = (CustomTestOperand) o;
-      return value.equals(that.value) &&
+      return value.equals(that.value)
+          &&
           prefix.equals(that.prefix);
     }
 
@@ -424,7 +424,7 @@ public class AstTest {
     }
   }
 
-  private static class StringOperandSupplier implements
+  public static class StringOperandSupplier implements
       NodeSupplier<DrgLexerToken, MaskedContext<String>> {
 
     @Override
@@ -482,12 +482,15 @@ public class AstTest {
 
     private List<T> mask;
     private Set<T> accumulator;
+    private List<T> evaluatedValuesInOrderOfEvaluation;
 
     public TestContext(List<T> mask) {
       this.mask = mask;
       this.accumulator = new HashSet<>();
+      this.evaluatedValuesInOrderOfEvaluation = new ArrayList<>();
     }
 
+    @Override
     public List<T> getMask() {
       return mask;
     }
@@ -504,6 +507,7 @@ public class AstTest {
       this.accumulator = accumulator;
     }
 
+    @Override
     public void accumulate(T value) {
       this.accumulator.add(value);
     }
@@ -512,6 +516,16 @@ public class AstTest {
     public Set<T> getMatches() {
       return accumulator;
     }
+
+    @Override
+    public void evaluating(T value) {
+      this.evaluatedValuesInOrderOfEvaluation.add(value);
+    }
+
+    public List<T> getEvaluatedValuesInOrderOfEvaluation() {
+      return evaluatedValuesInOrderOfEvaluation;
+    }
+
   }
 
   public static class ContainsNodeForContext<T> implements BooleanExpression<MaskedContext<T>> {
@@ -524,6 +538,7 @@ public class AstTest {
 
     @Override
     public boolean evaluate(MaskedContext<T> context) {
+      context.evaluating(value);
       if (context.getMask().contains(value)) {
         context.accumulate(value);
         return true;
@@ -537,6 +552,8 @@ public class AstTest {
     List<T> getMask();
 
     void accumulate(T value);
+
+    void evaluating(T value);
 
     Set<T> getMatches();
   }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
@@ -7,17 +7,18 @@ import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
+import com.mmm.his.cer.utility.farser.ast.setup.ContainsNodeForContext;
+import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -477,83 +478,4 @@ public class AstTest {
     }
   }
 
-  public static class TestContext<T> implements MaskedContext<T> {
-
-    private List<T> mask;
-    private Set<T> accumulator;
-    private List<T> evaluatedValuesInOrderOfEvaluation;
-
-    public TestContext(List<T> mask) {
-      this.mask = mask;
-      this.accumulator = new HashSet<>();
-      this.evaluatedValuesInOrderOfEvaluation = new ArrayList<>();
-    }
-
-    @Override
-    public List<T> getMask() {
-      return mask;
-    }
-
-    public void setMask(List<T> mask) {
-      this.mask = mask;
-    }
-
-    public Set<T> getAccumulator() {
-      return accumulator;
-    }
-
-    public void setAccumulator(Set<T> accumulator) {
-      this.accumulator = accumulator;
-    }
-
-    @Override
-    public void accumulate(T value) {
-      this.accumulator.add(value);
-    }
-
-    @Override
-    public Set<T> getMatches() {
-      return accumulator;
-    }
-
-    @Override
-    public void evaluating(T value) {
-      this.evaluatedValuesInOrderOfEvaluation.add(value);
-    }
-
-    public List<T> getEvaluatedValuesInOrderOfEvaluation() {
-      return evaluatedValuesInOrderOfEvaluation;
-    }
-
-  }
-
-  public static class ContainsNodeForContext<T> implements BooleanExpression<MaskedContext<T>> {
-
-    private T value;
-
-    public ContainsNodeForContext(T value) {
-      this.value = value;
-    }
-
-    @Override
-    public boolean evaluate(MaskedContext<T> context) {
-      context.evaluating(value);
-      if (context.getMask().contains(value)) {
-        context.accumulate(value);
-        return true;
-      }
-      return false;
-    }
-  }
-
-  public interface MaskedContext<T> {
-
-    List<T> getMask();
-
-    void accumulate(T value);
-
-    void evaluating(T value);
-
-    Set<T> getMatches();
-  }
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
@@ -1,0 +1,146 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.mmm.his.cer.utility.farser.ast.AstTest.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.AstTest.TestContext;
+import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
+import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
+import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class OperandAndEvaluationOrderTest {
+
+
+  @Test
+  public void testOperandAndEvaluationOrder1_noParenthesis() throws Exception {
+
+    String formula = "A & B | C";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("A", "B"));
+
+  }
+
+  @Test
+  public void testOperandAndEvaluationOrder1_withParenthesisForAnd() throws Exception {
+
+    String formula = "(A & B) | C";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("A", "B"));
+
+  }
+
+  @Test
+  public void testOperandAndEvaluationOrder1_withParenthesisForOr() throws Exception {
+
+    String formula = "A & (B | C)";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("A", "B"));
+
+  }
+
+  @Test
+  public void testOperandAndEvaluationOrder2_noParenthesis() throws Exception {
+
+    String formula = "C | A & B";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("C"));
+
+  }
+
+  @Test
+  public void testOperandAndEvaluationOrder2_withParenthesisForAnd() throws Exception {
+
+    String formula = "C | (A & B)";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("C"));
+
+  }
+
+  @Test
+  public void testOperandAndEvaluationOrder2_withParenthesisForOr() throws Exception {
+
+    String formula = "(C | A) & B";
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex(formula);
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    DrgSyntaxTree<MaskedContext<String>> ast = parser.buildExpressionTree();
+
+    // Ensure that evaluation is left-to-right and only the relevant parts of the formula get
+    // evaluated until 'true' is determined.
+    List<String> mask = Arrays.asList("A", "B", "C");
+    TestContext<String> context = new TestContext<>(mask);
+    ast.evaluateExpression(context);
+    System.out.println("Evaluated:" + context.getEvaluatedValuesInOrderOfEvaluation());
+    assertThat(context.getEvaluatedValuesInOrderOfEvaluation(), contains("C", "B"));
+
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
@@ -3,10 +3,10 @@ package com.mmm.his.cer.utility.farser.ast;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-import com.mmm.his.cer.utility.farser.ast.AstTest.MaskedContext;
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
-import com.mmm.his.cer.utility.farser.ast.AstTest.TestContext;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
+import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.Arrays;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
@@ -1,0 +1,22 @@
+package com.mmm.his.cer.utility.farser.ast.setup;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+
+public class ContainsNodeForContext<T> implements BooleanExpression<MaskedContext<T>> {
+
+  private T value;
+
+  public ContainsNodeForContext(T value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean evaluate(MaskedContext<T> context) {
+    context.evaluating(value);
+    if (context.getMask().contains(value)) {
+      context.accumulate(value);
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/MaskedContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/MaskedContext.java
@@ -1,0 +1,15 @@
+package com.mmm.his.cer.utility.farser.ast.setup;
+
+import java.util.List;
+import java.util.Set;
+
+public interface MaskedContext<T> {
+
+  List<T> getMask();
+
+  void accumulate(T value);
+
+  void evaluating(T value);
+
+  Set<T> getMatches();
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/StringOperandSupplier.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/StringOperandSupplier.java
@@ -1,0 +1,14 @@
+package com.mmm.his.cer.utility.farser.ast.setup;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+
+public class StringOperandSupplier implements
+    NodeSupplier<DrgLexerToken, MaskedContext<String>> {
+
+  @Override
+  public BooleanExpression<MaskedContext<String>> createNode(DrgLexerToken token) {
+    return new ContainsNodeForContext<>(token.value);
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/TestContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/TestContext.java
@@ -1,0 +1,56 @@
+package com.mmm.his.cer.utility.farser.ast.setup;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TestContext<T> implements MaskedContext<T> {
+
+  private List<T> mask;
+  private Set<T> accumulator;
+  private List<T> evaluatedValuesInOrderOfEvaluation;
+
+  public TestContext(List<T> mask) {
+    this.mask = mask;
+    this.accumulator = new HashSet<>();
+    this.evaluatedValuesInOrderOfEvaluation = new ArrayList<>();
+  }
+
+  @Override
+  public List<T> getMask() {
+    return mask;
+  }
+
+  public void setMask(List<T> mask) {
+    this.mask = mask;
+  }
+
+  public Set<T> getAccumulator() {
+    return accumulator;
+  }
+
+  public void setAccumulator(Set<T> accumulator) {
+    this.accumulator = accumulator;
+  }
+
+  @Override
+  public void accumulate(T value) {
+    this.accumulator.add(value);
+  }
+
+  @Override
+  public Set<T> getMatches() {
+    return accumulator;
+  }
+
+  @Override
+  public void evaluating(T value) {
+    this.evaluatedValuesInOrderOfEvaluation.add(value);
+  }
+
+  public List<T> getEvaluatedValuesInOrderOfEvaluation() {
+    return evaluatedValuesInOrderOfEvaluation;
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/DomainCodeLexerTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/DomainCodeLexerTest.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.lexer;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import com.mmm.his.cer.utility.farser.lexer.domain.DomainCodeLexerToken;
 import com.mmm.his.cer.utility.farser.lexer.domain.DomainCodeToken;
 import java.util.List;

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/DrgFormulaLexerTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/DrgFormulaLexerTest.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.lexer;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgFormulaToken;

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/SimpleLexerTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/SimpleLexerTest.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.lexer.tokentype;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import com.mmm.his.cer.utility.farser.lexer.FarserException;
 import com.mmm.his.cer.utility.farser.lexer.Lexer;
 import java.util.List;


### PR DESCRIPTION
Addition testing of formula evaluation order. Operator precedence and evaluation order documented.

~A few generic type names aligned (`C` types) and their javadoc updated. This helped me a lot to get into using farser again and figuring out how to construct all object types.~
Generic types reverted, and others aligned to use `R` for return types, `T` for classes with single generic types.

Various javadoc updates.

`equals`/`hashCode` added to lexer token classes.